### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 django-jquery-autosuggest
 =========================
 
-![Version Badge](https://pypip.in/v/django-jquery-autosuggest/badge.png)  
-![Downloads Badge](https://pypip.in/d/django-jquery-autosuggest/badge.png)  
-![Wheel Status Badge](https://pypip.in/wheel/django-jquery-autosuggest/badge.png)  
-![License Badge](https://pypip.in/license/django-jquery-autosuggest/badge.png)  
+![Version Badge](https://img.shields.io/pypi/v/django-jquery-autosuggest.svg)  
+![Downloads Badge](https://img.shields.io/pypi/dm/django-jquery-autosuggest.svg)  
+![Wheel Status Badge](https://img.shields.io/pypi/wheel/django-jquery-autosuggest.svg)  
+![License Badge](https://img.shields.io/pypi/l/django-jquery-autosuggest.svg)  


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-jquery-autosuggest))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-jquery-autosuggest`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.